### PR TITLE
Fix the negative offset issue

### DIFF
--- a/src/com/cfelde/bohmap/BOHMap.java
+++ b/src/com/cfelde/bohmap/BOHMap.java
@@ -127,6 +127,10 @@ public class BOHMap implements Map<Binary, Binary> {
         return address;
     }
 
+    private long getPartitionOffset(byte[] keyData) {
+        return Math.abs(hashFunction.apply(keyData) % partitionCount);
+    }
+
     @Override
     public int size() {
         if (itemCount > Integer.MAX_VALUE)
@@ -148,10 +152,9 @@ public class BOHMap implements Map<Binary, Binary> {
         final Binary bKey = (Binary) key;
         final byte[] keyData = bKey.getValue();
         final int keySize = keyData.length;
-        
-        final int hash = Math.abs(hashFunction.apply(keyData));
-        final long offset = hash % partitionCount;
-        
+
+        final long offset = getPartitionOffset(keyData);
+
         // This is the location of the partition on which the entry key belongs
         long locationAddress = unsafe.getAddress(partitionAddress + (offset * addressSize));
 
@@ -272,10 +275,9 @@ public class BOHMap implements Map<Binary, Binary> {
         final Binary bKey = (Binary) key;
         final byte[] keyData = bKey.getValue();
         final int keySize = keyData.length;
-        
-        final int hash = Math.abs(hashFunction.apply(keyData));
-        final long offset = hash % partitionCount;
-        
+
+        final long offset = getPartitionOffset(keyData);
+
         // This is the location of the partition on which the entry key belongs
         long locationAddress = unsafe.getAddress(partitionAddress + (offset * addressSize));
 
@@ -343,10 +345,9 @@ public class BOHMap implements Map<Binary, Binary> {
     public Binary put(Binary key, Binary value) {
         final byte[] keyData = key.getValue();
         final int keySize = keyData.length;
-        
-        final int hash = Math.abs(hashFunction.apply(keyData));
-        final long offset = hash % partitionCount;
-        
+
+        final long offset = getPartitionOffset(keyData);
+
         // This is the location of the partition on which the entry key belongs
         long locationAddress = unsafe.getAddress(partitionAddress + (offset * addressSize));
 
@@ -488,10 +489,9 @@ public class BOHMap implements Map<Binary, Binary> {
         final Binary bKey = (Binary) key;
         final byte[] keyData = bKey.getValue();
         final int keySize = keyData.length;
-        
-        final int hash = Math.abs(hashFunction.apply(keyData));
-        final long offset = hash % partitionCount;
-        
+
+        final long offset = getPartitionOffset(keyData);
+
         // This is the location of the partition on which the entry key belongs
         long locationAddress = unsafe.getAddress(partitionAddress + (offset * addressSize));
 


### PR DESCRIPTION
The PR does the following:

1. Extract the partition offset calculation code into a common private method, which helps to reuse the code.
2. Make the modulo operation first, apply the `Math.abs` function second, which solves the issue itself by making the `Math.abs(Integer.MIN_VALUE)` call impossible.

Fixes #1 